### PR TITLE
feat: character and words count display

### DIFF
--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/CountDisplay.styles.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/CountDisplay.styles.tsx
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+export const StyledCountDisplay = styled("div")`
+  align-items: center;
+  justify-content: flex-end;
+  color: rgba(102, 102, 135, 1);
+  display: flex;
+  font-size: 0.75rem;
+  gap: 0.5rem;
+  margin: 1.5rem;
+
+  svg {
+    color: rgba(73, 69, 255, 1);
+  }
+
+  &--warning,
+  &--warning svg {
+    color: rgba(208, 43, 32, 1);
+  }
+`;

--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/CountDisplay.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/CountDisplay.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import { StyledCountDisplay } from "./CountDisplay.styles";
 
 interface CountDisplayProps {
@@ -6,12 +7,15 @@ interface CountDisplayProps {
   limit: number | undefined;
 }
 
-export default function CountDisplay({
+export default memo(function CountDisplay({
   characters,
   limit,
   words,
 }: CountDisplayProps) {
-  const percentage = limit ? Math.round((100 / limit) * characters) : 0;
+  const percentage = useMemo(
+    () => (limit ? Math.round((100 / limit) * characters) : 0),
+    [characters, limit]
+  );
 
   return (
     <StyledCountDisplay
@@ -39,4 +43,4 @@ export default function CountDisplay({
       {words} words
     </StyledCountDisplay>
   );
-}
+});

--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/CountDisplay.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/CountDisplay.tsx
@@ -1,0 +1,42 @@
+import { StyledCountDisplay } from "./CountDisplay.styles";
+
+interface CountDisplayProps {
+  characters: number;
+  words: number;
+  limit: number | undefined;
+}
+
+export default function CountDisplay({
+  characters,
+  limit,
+  words,
+}: CountDisplayProps) {
+  const percentage = limit ? Math.round((100 / limit) * characters) : 0;
+
+  return (
+    <StyledCountDisplay
+      className={characters === limit ? "character-count--warning" : ""}
+    >
+      {limit && (
+        <svg height="20" width="20" viewBox="0 0 20 20">
+          <circle r="10" cx="10" cy="10" fill="#eaeaef" />
+          <circle
+            r="5"
+            cx="10"
+            cy="10"
+            fill="transparent"
+            stroke="currentColor"
+            strokeWidth="10"
+            strokeDasharray={`${(percentage * 31.4) / 100} 31.4`}
+            transform="rotate(-90) translate(-20)"
+          />
+          <circle r="6" cx="10" cy="10" fill="white" />
+        </svg>
+      )}
+      {characters}
+      {limit && ` / ${limit}`} characters
+      <br />
+      {words} words
+    </StyledCountDisplay>
+  );
+}

--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/Editor.styles.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/Editor.styles.tsx
@@ -6,9 +6,11 @@ export const StyledEditor = styled("div")`
 
   .tiptap {
     outline: none;
+    overflow-y: auto;
     line-height: 1.25rem;
     color: ${({ theme }) => theme.colors.neutral800};
     min-height: 80px;
+    max-height: 70vh;
     padding: 0 1.5rem 1.5rem 1.5rem;
 
     border-bottom-left-radius: 5px;

--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/Editor.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/Editor.tsx
@@ -2,6 +2,7 @@ import { EditorContent, Extension, Mark, Node, useEditor } from "@tiptap/react";
 import { Blockquote } from "@tiptap/extension-blockquote";
 import { Bold } from "@tiptap/extension-bold";
 import { BulletList } from "@tiptap/extension-bullet-list";
+import { CharacterCount } from "@tiptap/extension-character-count";
 import { Code } from "@tiptap/extension-code";
 import { CodeBlock } from "@tiptap/extension-code-block";
 import { Document } from "@tiptap/extension-document";
@@ -25,11 +26,17 @@ import { Youtube } from "@tiptap/extension-youtube";
 
 import Toolbar from "./Toolbar";
 import { StyledEditor } from "./Editor.styles";
+import CountDisplay from "./CountDisplay";
+
+const limit = undefined;
 
 const extensions: (Extension | Node | Mark)[] = [
   Blockquote,
   Bold,
   BulletList,
+  CharacterCount.configure({
+    limit,
+  }),
   Code,
   CodeBlock,
   Document,
@@ -76,10 +83,19 @@ export default function Editor({ initialContent, onChange }: EditorProps) {
     },
   });
 
+  if (!editor) {
+    return null;
+  }
+
   return (
     <StyledEditor data-plugin-rich-text-editor>
       <Toolbar editor={editor} />
       <EditorContent editor={editor} />
+      <CountDisplay
+        characters={editor.storage.characterCount.characters()}
+        words={editor.storage.characterCount.words()}
+        limit={limit}
+      />
     </StyledEditor>
   );
 }


### PR DESCRIPTION
### What does it do?
It adds a display for character and word counts.

### Why is it needed?
Content managers would like to count the characters and words in the content to fit it better to the SEO conventions.

### How to test it?
Write your content, look on the right bottom corner, you will see the counter.

### Notes
